### PR TITLE
Compute git gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,25 @@ Selects sign to use for version specification; this will be mapped from a number
 ### -p, --path STRING                
 Define path in which `Gemfile` and `Gemfile.lock` are located. Defaults to current directory.
 
+### -g, --git-gems                   
+Include GIT gems from Gemfile.lock in Gemfile reconstruction. This is off by default and will only affect the `--lock` command.
+Note: This is not guaranteed to support branch or commit specification.
+Gem lines are normalized to have the version and the remote under the `git:` key, like in this example:
+
+#### Input (Gemfile.lock fragment)
+```
+GIT
+  remote: https://github.com/jhawthorn/nsa.git
+  revision: e020fcc3a54d993ab45b7194d89ab720296c111b
+  ref: e020fcc3a54d993ab45b7194d89ab720296c111b
+  specs:
+    nsa (0.2.8)
+```
+#### Output
+```ruby
+gem 'nsa', '0.2.8', git: 'https://github.com/jhawthorn/nsa.git'
+```
+
 ### -l, --lock                       
 Rebuilds Gemfile using versions specified in Gemfile.lock; default sign for versions is '~>' and default depth is 2 (major & minor versions, ignores patch version).
 
@@ -241,7 +260,7 @@ end
 - [x] Add option to ignore Gemfile lines with `# LOCK` commented to the right end of the line
 - [x] Normalize git gems with rubygems from Gemfile.lock
 - [x] Add logic to ignore any comments in Gemfile gem lines
-- [ ] Normalize gems from other sources (such as GIT) with rubygems from Gemfile.lock
+- [x] Normalize git gems with rubygems-sourced gems from Gemfile.lock
 
 ## Development
 

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -14,6 +14,7 @@ module Lapidario
       @version_sign ||= '~>'
       @save_new_gemfile ||= false
       @save_backup ||= true if @save_backup.nil? # conditional assignment also executes on non-nil falsey values
+      @include_git_gems ||= false
     end
 
     def parse_options(options)
@@ -48,6 +49,10 @@ module Lapidario
           @project_path_hash = { project_path: project_path }
         end
 
+        opts.on("-g", "--git-gems", "Include GIT gems from Gemfile.lock in Gemfile reconstruction") do
+          @include_git_gems = true
+        end
+
         opts.on("-l", "--lock", "Rebuild Gemfile using versions specified in Gemfile.lock; default sign is '~>' and default depth is 2 (major & minor versions, ignores patch)") do
           @lock_gemfile = true
         end
@@ -71,7 +76,7 @@ module Lapidario
     end
 
     def start
-      info_instances = Lapidario.get_gemfile_and_lockfile_info(@project_path_hash)
+      info_instances = Lapidario.get_gemfile_and_lockfile_info(@project_path_hash, @include_git_gems)
       gemfile_info = info_instances[0]
       lockfile_info = info_instances[1]
       original_gemfile_lines = gemfile_info.original_gemfile

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -99,7 +99,8 @@ module Lapidario
           break
         end
       end
-      [name, "'#{version}', git: '#{remote}'"]
+      version_and_remote = "'#{version}', git: '#{remote}'"
+      [name, version_and_remote]
     end
   end
 end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -78,5 +78,28 @@ module Lapidario
       # {4}: Indicates exactly 4 occurrences of the preceding character (whitespace in this case).
       line.match?(/\A\x20{4}[A-Za-z0-9]/)
     end
+
+    def self.extract_git_gem_info(git_gem_fragment)
+      remote = ""
+      # extract repo address
+      git_gem_fragment.each do |line|
+        if line.match?(/^\s*remote:\s/)
+          remote = line.split(":", 2)[1].strip 
+          break
+        end
+      end
+      name = ""
+      version = ""
+      # extract gem name and version
+      git_gem_fragment.each_with_index do |line, index|
+        if line.match?(/^\s*specs:$/) # gem name will come immediately after 'specs'
+          gem_name_line = git_gem_fragment[index + 1].gsub(/\s/, '')
+          name = gem_name_line.split("(")[0]
+          version = gem_name_line.split("(")[1].sub(")", '')
+          break
+        end
+      end
+      [name, "'#{version}', git: '#{remote}'"]
+    end
   end
 end

--- a/lib/helper.rb
+++ b/lib/helper.rb
@@ -99,7 +99,7 @@ module Lapidario
           break
         end
       end
-      version_and_remote = "'#{version}', git: '#{remote}'"
+      version_and_remote = "#{version}, git: '#{remote}'"
       [name, version_and_remote]
     end
   end

--- a/lib/lockfile_info.rb
+++ b/lib/lockfile_info.rb
@@ -6,8 +6,8 @@ module Lapidario
   class LockfileInfo
     attr_accessor :primary_gems, :git_gems, :rubygems_gems
     
-    def initialize(gemfile_lock_as_strings, skip_git = true)
-      @git_gems = Lapidario::LockfileInfo.get_git_gems_from_gemfile_lock(gemfile_lock_as_strings) unless skip_git
+    def initialize(gemfile_lock_as_strings, include_git = true)
+      @git_gems = Lapidario::LockfileInfo.get_git_gems_from_gemfile_lock(gemfile_lock_as_strings) if include_git
       @git_gems ||= {}
       @rubygems_gems = Lapidario::LockfileInfo.get_rubygems_from_gemfile_lock(gemfile_lock_as_strings)
       # joins gem names and versions from git/rubygems/other sources in a single format

--- a/lib/lockfile_info.rb
+++ b/lib/lockfile_info.rb
@@ -4,13 +4,14 @@ require_relative "helper"
 
 module Lapidario
   class LockfileInfo
-    attr_accessor :primary_gems
+    attr_accessor :primary_gems, :git_gems, :rubygems_gems
     
-    def initialize(gemfile_lock_as_strings)
-      @git_gems = []
+    def initialize(gemfile_lock_as_strings, skip_git = true)
+      @git_gems = Lapidario::LockfileInfo.get_git_gems_from_gemfile_lock(gemfile_lock_as_strings) unless skip_git
+      @git_gems ||= {}
       @rubygems_gems = Lapidario::LockfileInfo.get_rubygems_from_gemfile_lock(gemfile_lock_as_strings)
       # joins gem names and versions from git/rubygems/other sources in a single format
-      @primary_gems = @rubygems_gems
+      @primary_gems = @git_gems.merge(@rubygems_gems)
     end
 
     def puts_versionless_rubygems_info
@@ -22,7 +23,7 @@ module Lapidario
     end
 
     def git_gems?
-      puts "TODO"
+      @git_gems && !@git_gems.empty?
     end
 
     # gets gems installed from rubygems; in the future check also for other remote sources
@@ -44,6 +45,26 @@ module Lapidario
         name = gem_name_and_version[0]
         version = gem_name_and_version[1]
         gem_names_and_versions[name] = version ? version.gsub(/[()]/, "") : ""
+      end
+      gem_names_and_versions
+    end
+
+    # gets gems under GIT namespace
+    def self.get_git_gems_from_gemfile_lock(gemfile_lock_as_strings)
+      git_gem_sections = []
+      gem_names_and_versions = {}
+      gemfile_lock_as_strings.each_with_index do |line, index|
+        git_gem_sections << Helper.slice_up_to_next_empty_line(index, gemfile_lock_as_strings) if line == "GIT"
+      end
+
+      return [] if git_gem_sections.empty?
+
+      git_gem_sections.each do |git_gem|
+        git_gem_info = Lapidario::Helper.extract_git_gem_info git_gem
+
+        name = git_gem_info[0]
+        version_and_remote = git_gem_info[1]
+        gem_names_and_versions[name] = version_and_remote
       end
       gem_names_and_versions
     end

--- a/spec/fixtures/final_gemfile_samples/Gemfile.git_simplified.hardcoded_from_lockfile
+++ b/spec/fixtures/final_gemfile_samples/Gemfile.git_simplified.hardcoded_from_lockfile
@@ -1,0 +1,6 @@
+gem 'webpush', '~> 0.3', git: 'https:/2/github.com/ClearlyClaire/webpush.git'
+gem 'nsa', '~> 0.', git: 'https://github.com/jhawthorn/nsa.git'
+gem 'rails-settings-cached', '~> 0.6', git: 'https://github.com/mastodon/rails-settings-cached.git'
+gem 'omniauth-cas', '~> 2.0', git: 'https://github.com/stanhu/omniauth-cas.git'
+gem 'actioncable', '~> 7.1'
+gem 'actionmailbox', '~> 7.1'

--- a/spec/fixtures/final_gemfile_samples/Gemfile.git_simplified.hardcoded_from_lockfile
+++ b/spec/fixtures/final_gemfile_samples/Gemfile.git_simplified.hardcoded_from_lockfile
@@ -1,5 +1,5 @@
-gem 'webpush', '~> 0.3', git: 'https:/2/github.com/ClearlyClaire/webpush.git'
-gem 'nsa', '~> 0.', git: 'https://github.com/jhawthorn/nsa.git'
+gem 'webpush', '~> 0.3', git: 'https://github.com/ClearlyClaire/webpush.git'
+gem 'nsa', '~> 0.2', git: 'https://github.com/jhawthorn/nsa.git'
 gem 'rails-settings-cached', '~> 0.6', git: 'https://github.com/mastodon/rails-settings-cached.git'
 gem 'omniauth-cas', '~> 2.0', git: 'https://github.com/stanhu/omniauth-cas.git'
 gem 'actioncable', '~> 7.1'

--- a/spec/fixtures/gemfile_samples/Gemfile.git_simplified
+++ b/spec/fixtures/gemfile_samples/Gemfile.git_simplified
@@ -1,0 +1,6 @@
+gem 'webpush'
+gem 'nsa'
+gem 'rails-settings-cached'
+gem 'omniauth-cas'
+gem 'actioncable'
+gem 'actionmailbox'

--- a/spec/fixtures/lockfile_samples/Gemfile.lock.git_simplified
+++ b/spec/fixtures/lockfile_samples/Gemfile.lock.git_simplified
@@ -1,0 +1,71 @@
+GIT
+  remote: https://github.com/ClearlyClaire/webpush.git
+  revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+  ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+  specs:
+    webpush (0.3.8)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
+
+GIT
+  remote: https://github.com/jhawthorn/nsa.git
+  revision: e020fcc3a54d993ab45b7194d89ab720296c111b
+  ref: e020fcc3a54d993ab45b7194d89ab720296c111b
+  specs:
+    nsa (0.2.8)
+      activesupport (>= 4.2, < 7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      sidekiq (>= 3.5)
+      statsd-ruby (~> 1.4, >= 1.4.0)
+
+GIT
+  remote: https://github.com/mastodon/rails-settings-cached.git
+  revision: 86328ef0bd04ce21cc0504ff5e334591e8c2ccab
+  branch: v0.6.6-aliases-true
+  specs:
+    rails-settings-cached (0.6.6)
+      rails (>= 4.2.0)
+
+GIT
+  remote: https://github.com/stanhu/omniauth-cas.git
+  revision: 4211e6d05941b4a981f9a36b49ec166cecd0e271
+  ref: 4211e6d05941b4a981f9a36b49ec166cecd0e271
+  specs:
+    omniauth-cas (2.0.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (>= 1.2, < 3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+
+PLATFORMS
+  x86_64-darwin-22
+
+DEPENDENCIES
+  bundler (~> 2)
+  lapidario!
+  pry (~> 0.14)
+  rake (~> 13.0)
+  rspec (~> 3.0)
+  rubocop (~> 1.21)
+
+BUNDLED WITH
+   2.4.10

--- a/spec/fixtures/project_path_sample/git_proj/Gemfile.lock
+++ b/spec/fixtures/project_path_sample/git_proj/Gemfile.lock
@@ -1,0 +1,71 @@
+GIT
+  remote: https://github.com/ClearlyClaire/webpush.git
+  revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+  ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+  specs:
+    webpush (0.3.8)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
+
+GIT
+  remote: https://github.com/jhawthorn/nsa.git
+  revision: e020fcc3a54d993ab45b7194d89ab720296c111b
+  ref: e020fcc3a54d993ab45b7194d89ab720296c111b
+  specs:
+    nsa (0.2.8)
+      activesupport (>= 4.2, < 7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      sidekiq (>= 3.5)
+      statsd-ruby (~> 1.4, >= 1.4.0)
+
+GIT
+  remote: https://github.com/mastodon/rails-settings-cached.git
+  revision: 86328ef0bd04ce21cc0504ff5e334591e8c2ccab
+  branch: v0.6.6-aliases-true
+  specs:
+    rails-settings-cached (0.6.6)
+      rails (>= 4.2.0)
+
+GIT
+  remote: https://github.com/stanhu/omniauth-cas.git
+  revision: 4211e6d05941b4a981f9a36b49ec166cecd0e271
+  ref: 4211e6d05941b4a981f9a36b49ec166cecd0e271
+  specs:
+    omniauth-cas (2.0.0)
+      addressable (~> 2.3)
+      nokogiri (~> 1.5)
+      omniauth (>= 1.2, < 3)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+      zeitwerk (~> 2.6)
+    actionmailbox (7.1.2)
+      actionpack (= 7.1.2)
+      activejob (= 7.1.2)
+      activerecord (= 7.1.2)
+      activestorage (= 7.1.2)
+      activesupport (= 7.1.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+
+PLATFORMS
+  x86_64-darwin-22
+
+DEPENDENCIES
+  bundler (~> 2)
+  lapidario!
+  pry (~> 0.14)
+  rake (~> 13.0)
+  rspec (~> 3.0)
+  rubocop (~> 1.21)
+
+BUNDLED WITH
+   2.4.10

--- a/spec/functional_tests/lapidario_spec.rb
+++ b/spec/functional_tests/lapidario_spec.rb
@@ -3,8 +3,10 @@
 require_relative '../spec_helper'
 
 SIMPLIFIED_GEM_AND_LOCKFILE_NAMES = "lapidario_v01"
+SIMPLIFIED_GIT_GEM_AND_LOCKFILE_NAMES = "git_simplified"
 
 SIMPLIFIED_FINAL_GEMFILE_FOR_COMPARISON = "lapidario_v01.hardcoded_from_lockfile"
+SIMPLIFIED_FINAL_GIT_GEMFILE_FOR_COMPARISON = "git_simplified.hardcoded_from_lockfile"
 
 RSpec.describe Lapidario do
   describe '.get_gemfile_and_lockfile_info' do
@@ -93,6 +95,26 @@ RSpec.describe Lapidario do
       let(:input_gemfile_path) { get_gemfile_path(SIMPLIFIED_GEM_AND_LOCKFILE_NAMES) }
       let(:input_lockfile_path) { get_lockfile_path(SIMPLIFIED_GEM_AND_LOCKFILE_NAMES) }
       let(:output_gemfile) { get_final_gemfile_stringified(SIMPLIFIED_FINAL_GEMFILE_FOR_COMPARISON) }
+
+      describe 'correctly produces a new gemfile' do
+        it 'with same versions of lockfile' do
+          project_path_hash = { gemfile_path: input_gemfile_path, lockfile_path: input_lockfile_path }
+          info_instances = Lapidario.get_gemfile_and_lockfile_info(project_path_hash)
+          gemfile_info = info_instances[0]
+          lockfile_info = info_instances[1]
+          original_gemfile_lines = gemfile_info.original_gemfile
+          new_gemfile_info = Lapidario.hardcode_lockfile_versions_into_gemfile_info(gemfile_info, lockfile_info)
+          new_gemfile = Lapidario.build_new_gemfile(new_gemfile_info, original_gemfile_lines)
+
+          expect(new_gemfile.join("\n")).to eq(output_gemfile)
+        end
+      end
+    end
+
+    context 'using simple gemfile & gemfile.lock with git gems' do
+      let(:input_gemfile_path) { get_gemfile_path(SIMPLIFIED_GIT_GEM_AND_LOCKFILE_NAMES) }
+      let(:input_lockfile_path) { get_lockfile_path(SIMPLIFIED_GIT_GEM_AND_LOCKFILE_NAMES) }
+      let(:output_gemfile) { get_final_gemfile_stringified(SIMPLIFIED_FINAL_GIT_GEMFILE_FOR_COMPARISON) }
 
       describe 'correctly produces a new gemfile' do
         it 'with same versions of lockfile' do

--- a/spec/functional_tests/lapidario_spec.rb
+++ b/spec/functional_tests/lapidario_spec.rb
@@ -88,19 +88,6 @@ RSpec.describe Lapidario do
     end
   end
 
-  describe '.save_gemfiles' do
-    let(:save_path) { Dir.pwd }
-    let(:original_gemfile) { ['gem "rails", "5.2.0"', 'gem "rspec", "3.9.0"'] }
-    let(:new_gemfile) { ['gem "rails", "6.0.0"', 'gem "rspec", "3.10.0"'] }
-
-    it 'saves original gemfile as backup and overwrites current Gemfile with new content' do
-      Lapidario.save_gemfiles(save_path, new_gemfile, original_gemfile)
-
-      expect(Lapidario::Helper).to have_received(:save_file).with(save_path + '/Gemfile.original', "gem \"rails\", \"5.2.0\"\ngem \"rspec\", \"3.9.0\"")
-      expect(Lapidario::Helper).to have_received(:save_file).with(save_path + '/Gemfile', "gem \"rails\", \"6.0.0\"\ngem \"rspec\", \"3.10.0\"")
-    end
-  end
-
   describe 'everything comes together' do
     context 'using simple gemfile & gemfile.lock' do
       let(:input_gemfile_path) { get_gemfile_path(SIMPLIFIED_GEM_AND_LOCKFILE_NAMES) }

--- a/spec/unit_tests/helper_spec.rb
+++ b/spec/unit_tests/helper_spec.rb
@@ -139,5 +139,29 @@ RSpec.describe Lapidario::Helper do
       end
     end
   end
+
+  describe '.extract_git_gem_info' do
+    let(:git_gem_fragment) do
+      [
+        "GIT",
+        "  remote: https://github.com/mastodon/rails-settings-cached.git",
+        "  revision: 86328ef0bd04ce21cc0504ff5e334591e8c2ccab",
+        "  branch: v0.6.6-aliases-true",
+        "  specs:",
+        "    rails-settings-cached (0.6.6)",
+        "      rails (>= 4.2.0)"
+      ]
+    end
+
+    subject { Lapidario::Helper.extract_git_gem_info(git_gem_fragment) }
+
+    it 'extracts the gem name correctly' do
+      expect(subject.first).to eq('rails-settings-cached')
+    end
+
+    it 'extracts the gem version and remote URL correctly' do
+      expect(subject.last).to eq("'0.6.6', git: 'https://github.com/mastodon/rails-settings-cached.git'")
+    end
+  end
   
 end

--- a/spec/unit_tests/lockfile_info_spec.rb
+++ b/spec/unit_tests/lockfile_info_spec.rb
@@ -3,16 +3,15 @@
 require_relative "../spec_helper"
 
 SIMPLE_LOCKFILE_PATH = "simplified"
-
+GIT_GEMS_LOCKFILE_PATH = "git_simplified"
 RSpec.describe Lapidario::LockfileInfo do
   describe "using simple lockfile" do
     let(:lockfile_as_array_of_strings) { Lapidario::Helper.get_file_as_array_of_lines(get_lockfile_path(SIMPLE_LOCKFILE_PATH)) }
     let(:lockfile_info) { described_class.new(lockfile_as_array_of_strings) }
 
     describe '#initialize' do
-      it 'initializes with Rubygems gems and empty git gems' do
+      it 'initializes with Rubygems gems' do
         expect(lockfile_info.instance_variable_get(:@rubygems_gems)).to eq({"ast"=>"2.4.2", "coderay"=>"1.1.3", "diff-lcs"=>"1.5.0", "json"=>"2.6.3", "language_server-protocol"=>"3.17.0.3", "rubocop-ast"=>"1.30.0", "ruby-progressbar"=>"1.13.0", "unicode-display_width"=>"2.5.0"})
-        expect(lockfile_info.instance_variable_get(:@git_gems)).to eq([])
       end
     end
 
@@ -33,8 +32,8 @@ RSpec.describe Lapidario::LockfileInfo do
     end
 
     describe '#git_gems?' do
-      it 'complete later' do
-        TODO
+      it 'returns false if there are no git gems' do
+        expect(lockfile_info.git_gems?).to eq(false)
       end
     end
 
@@ -55,8 +54,55 @@ RSpec.describe Lapidario::LockfileInfo do
     end
 
     describe '.get_git_gems_from_gemfile_lock' do
-      it 'puts TODO message' do
-        expect { described_class.get_git_gems_from_gemfile_lock([]) }.to output(/TODO/).to_stdout
+      it 'detects a GIT gem and stores its information' do
+        gemfile_lock_as_strings = %q(
+          GIT
+            remote: https://github.com/ClearlyClaire/webpush.git
+            revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+            ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+            specs:
+              webpush (0.3.8)
+                hkdf (~> 0.2)
+                jwt (~> 2.0)
+                
+          ).split("\n")
+        expect { described_class.get_git_gems_from_gemfile_lock(lockfile_as_array_of_strings) }.to output([{"webpush" => "0.3.8, git: 'https://github.com/ClearlyClaire/webpush.git'"}]).to_stdout
+      end
+    end
+  end
+
+  describe "using lockfile with both rubygems gems and git gems" do
+    let(:lockfile_as_array_of_strings) { Lapidario::Helper.get_file_as_array_of_lines(get_lockfile_path(GIT_GEMS_LOCKFILE_PATH)) }
+    let(:lockfile_info) { described_class.new(lockfile_as_array_of_strings) }
+    describe '#git_gems?' do
+      it 'returns true if there are git gems' do
+        expect(lockfile_info.git_gems?).to eq(true)
+      end
+    end
+
+    describe '.get_rubygems_from_gemfile_lock' do
+      it 'returns a hash of rubygems gems' do
+
+        result = described_class.get_rubygems_from_gemfile_lock(lockfile_as_array_of_strings)
+
+        expect(result).to eq('ast' => '2.4.2', 'rubocop' => '1.57.2', 'rspec' => '3.12.0',)
+      end
+    end
+
+    describe '.get_git_gems_from_gemfile_lock' do
+      it 'detects a GIT gem and stores its information' do
+        gemfile_lock_as_strings = %q(
+          GIT
+            remote: https://github.com/ClearlyClaire/webpush.git
+            revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+            ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
+            specs:
+              webpush (0.3.8)
+                hkdf (~> 0.2)
+                jwt (~> 2.0)
+                
+          ).split("\n")
+        expect(described_class.get_git_gems_from_gemfile_lock(lockfile_as_array_of_strings)).to eq("webpush" => "'0.3.8', git: 'https://github.com/ClearlyClaire/webpush.git'")
       end
     end
   end

--- a/spec/unit_tests/lockfile_info_spec.rb
+++ b/spec/unit_tests/lockfile_info_spec.rb
@@ -55,25 +55,24 @@ RSpec.describe Lapidario::LockfileInfo do
 
     describe '.get_git_gems_from_gemfile_lock' do
       it 'detects a GIT gem and stores its information' do
-        gemfile_lock_as_strings = %q(
-          GIT
-            remote: https://github.com/ClearlyClaire/webpush.git
-            revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
-            ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
-            specs:
-              webpush (0.3.8)
-                hkdf (~> 0.2)
-                jwt (~> 2.0)
-                
-          ).split("\n")
-        expect { described_class.get_git_gems_from_gemfile_lock(lockfile_as_array_of_strings) }.to output([{"webpush" => "0.3.8, git: 'https://github.com/ClearlyClaire/webpush.git'"}]).to_stdout
+        lockfile_as_array_of_strings = [
+          "GIT",
+          "  remote: https://github.com/ClearlyClaire/webpush.git",
+          "  revision: 86328ef0bd04ce21cc0504ff5e334591e8c2ccab",
+          "  branch: v0.6.6-aliases-true",
+          "  specs:",
+          "    webpush (0.3.8)",
+          "      rails (>= 4.2.0)",
+          ""
+        ]
+        expect(described_class.get_git_gems_from_gemfile_lock(lockfile_as_array_of_strings)).to eq({"webpush" => "'0.3.8', git: 'https://github.com/ClearlyClaire/webpush.git'"})
       end
     end
   end
 
   describe "using lockfile with both rubygems gems and git gems" do
     let(:lockfile_as_array_of_strings) { Lapidario::Helper.get_file_as_array_of_lines(get_lockfile_path(GIT_GEMS_LOCKFILE_PATH)) }
-    let(:lockfile_info) { described_class.new(lockfile_as_array_of_strings) }
+    let(:lockfile_info) { described_class.new(lockfile_as_array_of_strings, false) }
     describe '#git_gems?' do
       it 'returns true if there are git gems' do
         expect(lockfile_info.git_gems?).to eq(true)
@@ -85,7 +84,7 @@ RSpec.describe Lapidario::LockfileInfo do
 
         result = described_class.get_rubygems_from_gemfile_lock(lockfile_as_array_of_strings)
 
-        expect(result).to eq('ast' => '2.4.2', 'rubocop' => '1.57.2', 'rspec' => '3.12.0',)
+        expect(result).to eq({"actioncable"=>"7.1.2", "actionmailbox"=>"7.1.2"})
       end
     end
 
@@ -102,7 +101,11 @@ RSpec.describe Lapidario::LockfileInfo do
                 jwt (~> 2.0)
                 
           ).split("\n")
-        expect(described_class.get_git_gems_from_gemfile_lock(lockfile_as_array_of_strings)).to eq("webpush" => "'0.3.8', git: 'https://github.com/ClearlyClaire/webpush.git'")
+        result = described_class.get_git_gems_from_gemfile_lock(lockfile_as_array_of_strings)
+        expect(result).to eq({"webpush"=>"'0.3.8', git: 'https://github.com/ClearlyClaire/webpush.git'",
+        "nsa"=>"'0.2.8', git: 'https://github.com/jhawthorn/nsa.git'",
+        "rails-settings-cached"=>"'0.6.6', git: 'https://github.com/mastodon/rails-settings-cached.git'",
+        "omniauth-cas"=>"'2.0.0', git: 'https://github.com/stanhu/omniauth-cas.git'"})
       end
     end
   end


### PR DESCRIPTION
Adds functionality to insert git gems in a Gemfile.lock into lapidario's Gemfile rebuilding logic.
Example Gemfile.lock:

GIT
  remote: https://github.com/ClearlyClaire/webpush.git
  revision: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
  ref: f14a4d52e201128b1b00245d11b6de80d6cfdcd9
  specs:
    webpush (0.3.8)
      hkdf (~> 0.2)
      jwt (~> 2.0)

GIT
  remote: https://github.com/jhawthorn/nsa.git
  revision: e020fcc3a54d993ab45b7194d89ab720296c111b
  ref: e020fcc3a54d993ab45b7194d89ab720296c111b
  specs:
    nsa (0.2.8)
      activesupport (>= 4.2, < 7.2)
      concurrent-ruby (~> 1.0, >= 1.0.2)
      sidekiq (>= 3.5)
      statsd-ruby (~> 1.4, >= 1.4.0)

GIT
  remote: https://github.com/mastodon/rails-settings-cached.git
  revision: 86328ef0bd04ce21cc0504ff5e334591e8c2ccab
  branch: v0.6.6-aliases-true
  specs:
    rails-settings-cached (0.6.6)
      rails (>= 4.2.0)

GIT
  remote: https://github.com/stanhu/omniauth-cas.git
  revision: 4211e6d05941b4a981f9a36b49ec166cecd0e271
  ref: 4211e6d05941b4a981f9a36b49ec166cecd0e271
  specs:
    omniauth-cas (2.0.0)
      addressable (~> 2.3)
      nokogiri (~> 1.5)
      omniauth (>= 1.2, < 3)

GEM
  remote: https://rubygems.org/
  specs:
    actioncable (7.1.2)
      actionpack (= 7.1.2)
      activesupport (= 7.1.2)
      nio4r (~> 2.0)
      websocket-driver (>= 0.6.1)
      zeitwerk (~> 2.6)
    actionmailbox (7.1.2)
      actionpack (= 7.1.2)
      activejob (= 7.1.2)
      activerecord (= 7.1.2)
      activestorage (= 7.1.2)
      activesupport (= 7.1.2)
      mail (>= 2.7.1)
      net-imap
      net-pop
      net-smtp

PLATFORMS
  x86_64-darwin-22

DEPENDENCIES
  bundler (~> 2)
  lapidario!
  pry (~> 0.14)
  rake (~> 13.0)
  rspec (~> 3.0)
  rubocop (~> 1.21)

BUNDLED WITH
   2.4.10
